### PR TITLE
[FD] NGC-3251 Remove recently-added Help to Save scope

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -127,7 +127,7 @@ api-gateway {
   redirect_uri = "urn:ietf:wg:oauth:2.0:oob:auto"
   pathToAPIGatewayTokenService = "http://localhost:8236/oauth/token"
   pathToAPIGatewayAuthService = "http://localhost:8236/oauth/authorize"
-  scope = "read:personal-income+read:customer-profile+read:messages+read:submission-tracker+read:web-session+read:native-apps-api-orchestration+read:mobile-tax-credits-summary+read:mobile-tax-credits-renewal+read:help-to-save"
+  scope = "read:personal-income+read:customer-profile+read:messages+read:submission-tracker+read:web-session+read:native-apps-api-orchestration+read:mobile-tax-credits-summary+read:mobile-tax-credits-renewal"
   response_type = "code"
   tax_calc_server_token = "tax_calc_server_token"
   proxyPassthroughHttpHeaders = ["X-Vendor-Instance-ID", "X-Client-Device-ID"]


### PR DESCRIPTION
The Mobile Help to Save API will use an existing scope, read:native-apps-api-orchestration, instead of a new scope so that it can be called by the apps without requiring users to log in (and go through the OAuth grant process) again, which would be a bad user experience.