### PR TITLE
[NGC-3668][FD] Don't pass through Augur-related headers

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -136,7 +136,7 @@ api-gateway {
   scope = "read:personal-income+read:customer-profile+read:messages+read:submission-tracker+read:web-session+read:native-apps-api-orchestration"
   response_type = "code"
   tax_calc_server_token = "tax_calc_server_token"
-  proxyPassthroughHttpHeaders = ["X-Vendor-Instance-ID", "X-Client-Device-ID"]
+  proxyPassthroughHttpHeaders = []
   expiry_decrement = 600
 }
 


### PR DESCRIPTION
The apps are being changed to no longer send them so there's no need to pass them through.

Just changed the setting rather than removed the feature because there may be a requirement in future to pass through other similar headers (perhaps `Gov-Client-Device-ID` and `Gov-Vendor-Instance-ID`) - see Slack conversation linked from Jira NGC-3668.